### PR TITLE
Add instructions to enable .onion sites in FireFox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ such as Tasker or Owntracks.
 To our knowledge, there are currently no iOS apps available supporting the
 stealth feature.
 
+You can use the standard FireFox browser to access .onion domains, but you need to enable this in FireFix settings. In FireFox, type "about:config" in the address bar and click 'I accept the risk' to open the advanced settings. Search for "onion" to find the setting "network.dns.blockDotOnion" and toggle the setting so that it is set to "false". Now you should be able to access .onion sites.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]


### PR DESCRIPTION
# Proposed Changes

After setting up the tor add-on and creating a hidden .onion domain, you don't need the Tor browser, you can use standard FireFox if you want. But you need to enable it, so add instructions how to enable .onion domains in FireFox.

## Related Issues

