### PR TITLE
⬆️ Upgrades tor to 0.3.5.8-r0 (EDGE)

### DIFF
--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -11,7 +11,7 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-        tor@edge=0.3.4.9-r1
+        tor@edge=0.3.5.8-r0
 
 # Build arugments
 ARG BUILD_ARCH

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -11,7 +11,7 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-        tor=0.3.3.7-r0
+        tor@edge=0.3.4.9-r1
 
 # Build arugments
 ARG BUILD_ARCH


### PR DESCRIPTION
# Proposed Changes

As I proposed on Discord a while ago this PR upgrades the tor package to 0.3.4.9-r1 on edge.

The v3.8 branch is still 0.3.3.7 vs a stable 0.3.4.9 release on edge. Apparently this should improve performance, especially for low-power and embedded environments. Also, even the 0.3.3.x series is on 0.3.3.9 already, with memory leak fixes and the new bridge authority (Bifröst has been retired).