### PR TITLE
Change client definitions for stealth mode

### DIFF
--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -7,7 +7,7 @@ declare virtual_port
 declare target_port
 declare port
 declare host
-declare -a client_names
+declare clientname
 
 readonly torrc='/etc/tor/torrc'
 

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -45,10 +45,10 @@ if bashio::config.true 'hidden_services'; then
     done
 
     if bashio::config.true 'stealth'; then
-        mapfile -t client_names < <(bashio::config 'client_names')
-        IFS=','
-        echo "HiddenServiceAuthorizeClient stealth ${client_names[*]}" \
-            >> "$torrc"
+        for client in $(bashio::config 'client_names|keys'); do
+            clientname=$(bashio::config "client_names[${client}]")
+            echo "HiddenServiceAuthorizeClient stealth $clientname" >> "$torrc"
+        done
     fi
 
     echo 'HiddenServiceAllowUnknownPorts 0' >> "$torrc"


### PR DESCRIPTION
# Proposed Changes

> Not sure why this works, but it does 🤷‍♂️ 

Startup log after the change:

```text
-----------------------------------------------------------
 Hass.io Add-on: Tor
 Protect your privacy and access Home Assistant via Tor.
-----------------------------------------------------------
 Add-on version: dev
 You are running the latest version of this add-on.
 System: Debian GNU/Linux 9 (stretch)  (amd64 / qemux86-64)
 Home Assistant version: 0.90.1
 Supervisor version: 150
-----------------------------------------------------------
 Please, share the above information when looking for help
 or support in e.g, GitHub, forums or the Discord chat.
-----------------------------------------------------------
[cont-init.d] 00-banner.sh: exited 0.
[cont-init.d] 01-log-level.sh: executing... 
[cont-init.d] 01-log-level.sh: exited 0.
[cont-init.d] 10-requirements.sh: executing... 
[cont-init.d] 10-requirements.sh: exited 0.
[cont-init.d] 20-dirs.sh: executing... 
[cont-init.d] 20-dirs.sh: exited 0.
[cont-init.d] 50-tor-log.sh: executing... 
[cont-init.d] 50-tor-log.sh: exited 0.
[cont-init.d] 51-tor-socks.sh: executing... 
[cont-init.d] 51-tor-socks.sh: exited 0.
[cont-init.d] 52-tor-services.sh: executing... 
[cont-init.d] 52-tor-services.sh: exited 0.
[cont-init.d] 90-hostname.sh: executing... 
[21:44:57] INFO: Starting Tor temporarly...
[21:45:03] INFO: ---------------------------------------------------------
[21:45:03] INFO: Your Home Assistant instance is available on Tor!
[21:45:03] INFO: Addresses & Auth cookies:
[21:45:03] INFO: fqba5u5ky5asuru.onion Ft6XTjnxg6NJDIzPvGVSZB # client: hassiohassio
[21:45:03] INFO: ---------------------------------------------------------
[cont-init.d] 90-hostname.sh: exited 0.
[cont-init.d] done.
[services.d] starting services
[services.d] done.
[21:45:03] INFO: Starting Tor...
Mar 26 21:45:03.271 [notice] Tor 0.3.4.11 (git-4fd31340f3355342) running on Linux with Libevent 2.1.8-stable, OpenSSL 1.1.1b, Zlib 1.2.11, Liblzma N/A, and Libzstd N/A.
Mar 26 21:45:03.271 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://www.torproject.org/download/download#warning
Mar 26 21:45:03.271 [notice] Read configuration file "/etc/tor/torrc".
Mar 26 21:45:03.275 [notice] Scheduler type KIST has been enabled.
Mar 26 21:45:03.000 [notice] Parsing GEOIP IPv4 file /usr/share/tor/geoip.
Mar 26 21:45:03.000 [notice] Parsing GEOIP IPv6 file /usr/share/tor/geoip6.
Mar 26 21:45:03.000 [warn] You are running Tor as root. You don't need to, and you probably shouldn't.
Mar 26 21:45:03.000 [notice] Bootstrapped 0%: Starting
Mar 26 21:45:04.000 [notice] Starting with guard context "default"
Mar 26 21:45:04.000 [notice] Bootstrapped 80%: Connecting to the Tor network
Mar 26 21:45:04.000 [notice] Bootstrapped 85%: Finishing handshake with first hop
Mar 26 21:45:04.000 [notice] Bootstrapped 90%: Establishing a Tor circuit
Mar 26 21:45:04.000 [notice] Tor has successfully opened a circuit. Looks like client functionality is working.
Mar 26 21:45:04.000 [notice] Bootstrapped 100%: Done
```

## Related Issues

> fixes #12 