### PR TITLE
fixed client_names

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Enabling `stealth` can prevent a DDOS because if the client does not have the
 key, it can not find the path to the server. It does, however, require
 configuration of the client as well.
 
-### Option: `client_name`
+### Option: `client_names`
 
 This option is required as soon as you enable the `stealth` option.
 


### PR DESCRIPTION
there is no client_name option, it should be client_names

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/