### PR TITLE
Add missing port descriptions to add-on configuration

### DIFF
--- a/tor/config.json
+++ b/tor/config.json
@@ -10,6 +10,9 @@
   "ports": {
     "9050/tcp": 9050
   },
+  "ports_description": {
+    "9050/tcp": "Tor SOCKS proxy port"
+  },
   "map": ["ssl:rw"],
   "options": {
     "socks": false,


### PR DESCRIPTION
# Proposed Changes

Add a missing port description for the Tor SOCKS port that is exposed.
