### PR TITLE
Upgrade to Hidden Service v3

### DIFF
--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -13,7 +13,7 @@ readonly torrc='/etc/tor/torrc'
 
 if bashio::config.true 'hidden_services'; then
     echo 'HiddenServiceDir /ssl/tor/hidden_service' >> "$torrc"
-    echo 'HiddenServiceVersion 2' >> "$torrc"
+    echo 'HiddenServiceVersion 3' >> "$torrc"
     for port in $(bashio::config 'ports'); do
         count=$(echo "${port}" | sed 's/[^:]//g'| awk '{ print length }')
         if [[ "${count}" == 0 ]]; then


### PR DESCRIPTION
I only submit this patch because from the open issues it appears this essential addon is at risk of becoming totally useless by October when all tor browsers will officially be incompatible with v2, and that would be a shame.

# Proposed Changes

> Change HiddenServiceVersion from 2 to 3 in order for this addon to survive the impending depreciation of v2. Patch is fully tested as Local Addon. No issues, though users will obviously have to take note of the new domain & update any bookmarks to the old one. I 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
