### PR TITLE
Add Configuration-Options to support running a relay

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,0 @@
-{
-    "name": "Home Assistant Test Addons sebwi",
-    "url": "https://github.com/seppelw/addon-tor",
-    "maintainer": "seppel_w"
-  }

--- a/repository.json
+++ b/repository.json
@@ -1,0 +1,5 @@
+{
+    "name": "Home Assistant Test Addons sebwi",
+    "url": "https://github.com/seppelw/addon-tor",
+    "maintainer": "seppel_w"
+  }

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -11,7 +11,7 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-        tor=tor-0.4.6.9-r0
+        tor=0.4.6.9-r0
 
 # Build arguments
 ARG BUILD_ARCH

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:11.0.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:11.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -11,7 +11,7 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-        tor=0.4.6.8-r0
+        tor=tor-0.4.6.9-r0
 
 # Build arguments
 ARG BUILD_ARCH

--- a/tor/build.yaml
+++ b/tor/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:11.0.0
-  amd64: ghcr.io/hassio-addons/base/amd64:11.0.0
-  armhf: ghcr.io/hassio-addons/base/armhf:11.0.0
-  armv7: ghcr.io/hassio-addons/base/armv7:11.0.0
-  i386: ghcr.io/hassio-addons/base/i386:11.0.0
+  aarch64: ghcr.io/hassio-addons/base/aarch64:11.1.2
+  amd64: ghcr.io/hassio-addons/base/amd64:11.1.2
+  armhf: ghcr.io/hassio-addons/base/armhf:11.1.2
+  armv7: ghcr.io/hassio-addons/base/armv7:11.1.2
+  i386: ghcr.io/hassio-addons/base/i386:11.1.2

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -31,16 +31,18 @@ options:
   relayBandwidthRate: "1 MB"
   relayBandwidthBurst: "1 MB"
   relayNickName: ""
-  relayOrPort: '9001'
+  relayOrPort: 
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   socks: bool
   hidden_services: bool
   relay: bool
   stealth: bool
+  relayBandwidthRate: string
+  relayBandwidthBurst: string
+  relayOrPort: string
   client_names:
     - match(^[A-Za-z0-9+-_]{1,16}$)
-  relayNickName:
-    - match(^[A-Za-z0-9+-_]{1,16}$)
+  relayNickName: string
   ports:
     - match(^(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$)

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -31,13 +31,12 @@ options:
   relayBandwidthRate: "1 MB"
   relayBandwidthBurst: "1 MB"
   relayNickName: ""
-  relayOrProt: 9001
+  relayOrPort: '9001'
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   socks: bool
   hidden_services: bool
   relay: bool
-  relayOrProt: long
   stealth: bool
   client_names:
     - match(^[A-Za-z0-9+-_]{1,16}$)

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -28,8 +28,8 @@ options:
   ports:
     - "8123"
   relay: false
-  relayBandwidthRate: "1 MB"
-  relayBandwidthBurst: "1 MB"
+  relayBandwidthRate: 
+  relayBandwidthBurst: 
   relayNickName: ""
   relayOrPort: 
 schema:
@@ -38,11 +38,11 @@ schema:
   hidden_services: bool
   relay: bool
   stealth: bool
-  relayBandwidthRate: string
-  relayBandwidthBurst: string
-  relayOrPort: string
+  relayBandwidthRate: str
+  relayBandwidthBurst: str
+  relayOrPort: port
   client_names:
     - match(^[A-Za-z0-9+-_]{1,16}$)
-  relayNickName: string
+  relayNickName: str
   ports:
     - match(^(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$)

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -32,17 +32,21 @@ options:
   relayBandwidthBurst: 
   relayNickName: ""
   relayOrPort: 
+  contactInfo: 
+  exitPolicy: "reject *:*"
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   socks: bool
   hidden_services: bool
   relay: bool
   stealth: bool
-  relayBandwidthRate: str
-  relayBandwidthBurst: str
-  relayOrPort: port
+  relayBandwidthRate: str?
+  relayBandwidthBurst: str?
+  contactInfo: email?
+  exitPolicy: str?
+  relayOrPort: port?
   client_names:
     - match(^[A-Za-z0-9+-_]{1,16}$)
-  relayNickName: str
+  relayNickName: str?
   ports:
     - match(^(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$)

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -31,7 +31,7 @@ options:
   relayBandwidthRate: 
   relayBandwidthBurst: 
   relayNickName: ""
-  relayOrPort: 
+  relayOrPort: 9001
   contactInfo: 
   exitPolicy: "reject *:*"
 schema:
@@ -40,6 +40,7 @@ schema:
   hidden_services: bool
   relay: bool
   stealth: bool
+  relayNickName: str?
   relayBandwidthRate: str?
   relayBandwidthBurst: str?
   contactInfo: email?
@@ -47,6 +48,5 @@ schema:
   relayOrPort: port?
   client_names:
     - match(^[A-Za-z0-9+-_]{1,16}$)
-  relayNickName: str?
   ports:
     - match(^(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$)

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -14,8 +14,10 @@ arch:
 init: false
 ports:
   9050/tcp: 9050
+  9001/tcp: 9001
 ports_description:
   9050/tcp: Tor SOCKS proxy port
+  9001/tcp: Tor OR Port
 map:
   - ssl:rw
 options:
@@ -26,6 +28,8 @@ options:
   ports:
     - "8123"
   relay: false
+  RelayBandwidthRate: "1 MB"
+  RelayBandwidthBurst: "1 MB"
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   socks: bool

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -25,10 +25,12 @@ options:
   client_names: []
   ports:
     - "8123"
+  relay: false
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   socks: bool
   hidden_services: bool
+  relay: bool
   stealth: bool
   client_names:
     - match(^[A-Za-z0-9+-_]{1,16}$)

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -28,15 +28,20 @@ options:
   ports:
     - "8123"
   relay: false
-  RelayBandwidthRate: "1 MB"
-  RelayBandwidthBurst: "1 MB"
+  relayBandwidthRate: "1 MB"
+  relayBandwidthBurst: "1 MB"
+  relayNickName: ""
+  relayOrProt: 9001
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   socks: bool
   hidden_services: bool
   relay: bool
+  relayOrProt: long
   stealth: bool
   client_names:
+    - match(^[A-Za-z0-9+-_]{1,16}$)
+  relayNickName:
     - match(^[A-Za-z0-9+-_]{1,16}$)
   ports:
     - match(^(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$)

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -54,8 +54,6 @@ if bashio::config.true 'hidden_services'; then
     echo 'HiddenServiceAllowUnknownPorts 0' >> "$torrc"
 fi
 if bashio::config.true 'relay'; then
-    bashio::log.info "OrPort: "$(bashio::config 'relayOrPort')
-    bashio::log.info "OrPort: "$(bashio::config 'exitPolicy')
     echo 'ExitPolicy' "$(bashio::config 'exitPolicy')" >> "$torrc"
     echo 'BridgeRelay 0' >> "$torrc"
     echo 'ContactInfo ' $(bashio::config 'contactInfo') >> "$torrc"

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -59,6 +59,6 @@ if bashio::config.true 'relay'; then
     echo 'ContactInfo info@sebwiha.duckdns.org' >> "$torrc"
     echo 'Nickname TorSebwiHa' >> "$torrc"
     echo 'ORPort 9001' >> "$torrc"
-    echo 'RelayBandwidthRate: 20 MB' >> "$torrc"
-    echo 'RelayBandwidthBurst: 35 MB' >> "$torrc"
+    echo 'RelayBandwidthRate 2 MB' >> "$torrc"
+    echo 'RelayBandwidthBurst 5 MB' >> "$torrc"
 fi

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -53,3 +53,11 @@ if bashio::config.true 'hidden_services'; then
 
     echo 'HiddenServiceAllowUnknownPorts 0' >> "$torrc"
 fi
+if bashio::config.true 'relay'; then
+    echo 'ExitPolicy reject *:*' >> "$torrc"
+    echo 'BridgeRelay 0' >> "$torrc"
+    echo 'ContactInfo info@sebwiha.duckdns.org' >> "$torrc"
+    echo 'Nickname TorSebwiHa' >> "$torrc"
+    echo 'ORPort 9001' >> "$torrc"
+
+fi

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -54,11 +54,12 @@ if bashio::config.true 'hidden_services'; then
     echo 'HiddenServiceAllowUnknownPorts 0' >> "$torrc"
 fi
 if bashio::config.true 'relay'; then
+    bashio::log.info "OrPort: "$(bashio::config 'relayOrPort')
     echo 'ExitPolicy reject *:*' >> "$torrc"
     echo 'BridgeRelay 0' >> "$torrc"
     echo 'ContactInfo info@sebwiha.duckdns.org' >> "$torrc"
     echo 'Nickname ' "$(bashio::config 'relayNickName')"  >> "$torrc"
-    echo 'ORPort ' $(bashio::config 'relayOrProt') >> "$torrc"
+    echo 'ORPort ' $(bashio::config 'relayOrPort') >> "$torrc"
     echo 'RelayBandwidthRate '$(bashio::config 'relayBandwidthRate') >> "$torrc"
     echo 'RelayBandwidthBurst '$(bashio::config 'relayBandwidthBurst') >> "$torrc"
 fi

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -55,9 +55,10 @@ if bashio::config.true 'hidden_services'; then
 fi
 if bashio::config.true 'relay'; then
     bashio::log.info "OrPort: "$(bashio::config 'relayOrPort')
-    echo 'ExitPolicy reject *:*' >> "$torrc"
+    bashio::log.info "OrPort: "$(bashio::config 'exitPolicy')
+    echo 'ExitPolicy' "$(bashio::config 'exitPolicy')" >> "$torrc"
     echo 'BridgeRelay 0' >> "$torrc"
-    echo 'ContactInfo info@sebwiha.duckdns.org' >> "$torrc"
+    echo 'ContactInfo ' $(bashio::config 'contactInfo') >> "$torrc"
     echo 'Nickname ' "$(bashio::config 'relayNickName')"  >> "$torrc"
     echo 'ORPort ' $(bashio::config 'relayOrPort') >> "$torrc"
     echo 'RelayBandwidthRate '$(bashio::config 'relayBandwidthRate') >> "$torrc"

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -57,8 +57,8 @@ if bashio::config.true 'relay'; then
     echo 'ExitPolicy reject *:*' >> "$torrc"
     echo 'BridgeRelay 0' >> "$torrc"
     echo 'ContactInfo info@sebwiha.duckdns.org' >> "$torrc"
-    echo 'Nickname TorSebwiHa' >> "$torrc"
-    echo 'ORPort 9001' >> "$torrc"
-    echo 'RelayBandwidthRate 2 MB' >> "$torrc"
-    echo 'RelayBandwidthBurst 5 MB' >> "$torrc"
+    echo 'Nickname ' "$(bashio::config 'relayNickName')"  >> "$torrc"
+    echo 'ORPort ' $(bashio::config 'relayOrProt') >> "$torrc"
+    echo 'RelayBandwidthRate '$(bashio::config 'relayBandwidthRate') >> "$torrc"
+    echo 'RelayBandwidthBurst '$(bashio::config 'relayBandwidthBurst') >> "$torrc"
 fi

--- a/tor/rootfs/etc/cont-init.d/52-tor-services.sh
+++ b/tor/rootfs/etc/cont-init.d/52-tor-services.sh
@@ -59,5 +59,6 @@ if bashio::config.true 'relay'; then
     echo 'ContactInfo info@sebwiha.duckdns.org' >> "$torrc"
     echo 'Nickname TorSebwiHa' >> "$torrc"
     echo 'ORPort 9001' >> "$torrc"
-
+    echo 'RelayBandwidthRate: 20 MB' >> "$torrc"
+    echo 'RelayBandwidthBurst: 35 MB' >> "$torrc"
 fi


### PR DESCRIPTION
# Proposed Changes

The changes add the ability to use the add-on as a tor-relay by using the corresponding config parameters to add the necessary info to torrc

## Related Issues
https://github.com/hassio-addons/addon-tor/issues/134