### PR TITLE
:stethoscope: Add health check to improve HA watchdog

### DIFF
--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -15,6 +15,17 @@ RUN \
         openssl=3.0.7-r0 \
         tor=0.4.7.12-r0
 
+HEALTHCHECK \
+    --start-period=5m \
+    --interval=60s \
+    --timeout=30s \
+    CMD curl \
+        --silent \
+        --location \
+        --socks5-hostname localhost:9050 \
+        https://check.torproject.org/?lang=en_US \
+        | grep -qm1 Congratulations
+
 # Build arguments
 ARG BUILD_ARCH
 ARG BUILD_DATE

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -86,7 +86,7 @@ fi
 if bashio::config.true 'socks'; then
     echo 'SOCKSPort 0.0.0.0:9050' >> "${torrc}"
 else
-    echo 'SOCKSPort 0' >> "${torrc}"
+    echo 'SOCKSPort 127.0.0.1:9050' >> "${torrc}"
 fi
 
 # Configure hidden services


### PR DESCRIPTION
# Proposed Changes

Adds a health check that actually checks if the Tor connection is still active.
This allows Home Assistant's Supervisor to kick in using its Watchdog feature (in case there are issues).
