### PR TITLE
Reinstante openssl dependencies

### DIFF
--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -16,6 +16,7 @@ ARG WEBTUNNEL_VERSION=v0.0.2
 RUN \
     apk add --no-cache \
         coreutils=9.5-r2 \
+        openssl=3.3.3-r0 \
         tor=0.4.8.16-r0 \
     && apk add --no-cache --virtual .build-dependencies \
         go=1.23.9-r0 \


### PR DESCRIPTION
# Proposed Changes

Re-instantes the openssl dependencies

## Related Issues

> ([Github link][autolink-references]	 to related issues or pull requests)

fixes #271


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Tor addon to include the installation of the latest OpenSSL package for improved security and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->