### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -112,8 +109,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-tor.svg
 [commits]: https://github.com/hassio-addons/addon-tor/commits/main
 [contributors]: https://github.com/hassio-addons/addon-tor/graphs/contributors
@@ -128,7 +123,6 @@ SOFTWARE.
 [github-sponsors]: https://github.com/sponsors/frenck
 [github-actions-shield]: https://github.com/hassio-addons/addon-tor/workflows/CI/badge.svg
 [github-actions]: https://github.com/hassio-addons/addon-tor/actions
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-tor/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-tor.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/tor/build.yaml
+++ b/tor/build.yaml
@@ -2,4 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -8,7 +8,6 @@ startup: services
 arch:
   - aarch64
   - amd64
-  - armv7
 init: false
 ports:
   9050/tcp: 9050


### PR DESCRIPTION
# Proposed Changes

The Home Assistant project has deprecated armv7 support and will fully drop it in the Home Assistant 2025.12 release. This add-on drops it now as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for armhf, armv7, and i386 architecture variants. Only aarch64 and amd64 architectures are now supported.
  * Updated build configurations and documentation to reflect architecture changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->