### PR TITLE
Persist Tor data directory across restartsPersist Tor data directory across restarts

### DIFF
--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -17,7 +17,6 @@ ports_description:
   9080/tcp: Tor HTTP proxy port
 map:
   - ssl:rw
-  - data:rw
 options:
   socks: false
   http_tunnel: false

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -17,6 +17,7 @@ ports_description:
   9080/tcp: Tor HTTP proxy port
 map:
   - ssl:rw
+  - data:rw
 options:
   socks: false
   http_tunnel: false

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -59,6 +59,9 @@ mkdir -p \
     || bashio::exit.nok 'Could not create tor data directories'
 chmod -R 0700 /ssl/tor
 
+# Persist Tor state across restarts to speed up bootstrapping
+echo "DataDirectory /data" >> "${torrc}"
+
 # Find the matching Tor log level
 if bashio::config.has_value 'log_level'; then
     case "$(bashio::string.lower "$(bashio::config 'log_level')")" in


### PR DESCRIPTION
# Proposed Changes

Tor's network consensus, cached descriptors, and guard node state were previously lost on every restart, forcing a full re-download on each start. This significantly slows down bootstrapping.

## Related Issues

closes #262