### PR TITLE
Fix build on Alpine 3.24

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "depNameTemplate": "alpine_3_24/{{package}}"
     },
     {
       "customType": "regex",

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -15,12 +15,12 @@ ARG WEBTUNNEL_VERSION=v0.0.2
 # Setup base
 RUN \
     apk add --no-cache \
-        coreutils=9.8-r1 \
+        coreutils=9.11-r0 \
         openssl=3.5.7-r0 \
-        tor=0.4.9.8-r0 \
+        tor=0.4.9.11-r0 \
     && apk add --no-cache --virtual .build-dependencies \
-        go=1.25.10-r0 \
-        git=2.52.0-r0 \
+        go=1.26.3-r0 \
+        git=2.54.0-r0 \
     && git clone -b "${OBFS_VERSION}" --single-branch --depth 1 \
         https://github.com/Yawning/obfs4.git /tmp/obfs4 \
     && go build -C /tmp/obfs4 -ldflags '-extldflags "-static" -s -w' -o /usr/local/bin/obfs4proxy ./obfs4proxy \

--- a/tor/build.yaml
+++ b/tor/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:20.1.1
-  amd64: ghcr.io/hassio-addons/base:20.1.1
+  aarch64: ghcr.io/hassio-addons/base:21.0.1
+  amd64: ghcr.io/hassio-addons/base:21.0.1


### PR DESCRIPTION
# Proposed Changes

Fixes #327.

Migrate the add-on as one coordinated dependency update to the current base/Alpine generation instead of updating the affected packages independently:

- update `ghcr.io/hassio-addons/base` from `20.1.1` to `21.0.1`;
- update Alpine package pins for Alpine 3.24;
- update Tor to `0.4.9.11-r0`;
- update the Renovate Repology namespace from `alpine_3_23` to `alpine_3_24`.

This intentionally leaves the workflows v3 migration and the Snowflake/WebTunnel Renovate lookup fixes for separate follow-up changes.

## Validation

The same branch was validated in the fork using this repository's reusable CI workflow:

- Shellcheck: pass
- Prettier: pass
- JSON Lint: pass
- YAMLLint: pass
- zizmor: pass
- Hadolint: pass
- App Lint: pass
- Build amd64: pass
- Build aarch64: pass

The fork-only Dependency review failure is caused by Dependency Graph being disabled on the newly created fork; this draft PR is also intended to validate the change in the upstream repository context.

Test PR: https://github.com/eXPerience83/app-tor/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s underlying runtime and build components to newer supported versions.
  * Refreshed container images for ARM64 and AMD64 platforms.
  * Updated Alpine Linux release metadata used in automated maintenance.
* **Maintenance**
  * Improved platform compatibility and maintainability without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->