### PR TITLE
Resolve Home Assistant hidden-service target port dynamically

### DIFF
--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -51,7 +51,7 @@ client_names:
   - haremote1
   - haremote2
 ports:
-  - 8123
+  - 80
 bridges: []
 ```
 
@@ -140,7 +140,18 @@ section below for details.
 Configures hosts and ports to publish via a Tor Hidden Service.
 You can list multiple hosts and ports to publish.
 
-For example:
+New installations default to Onion port `80` for Home Assistant:
+
+```yaml
+ports:
+  - 80
+```
+
+The app resolves the actual Home Assistant Core HTTP target port from
+Supervisor at startup, so the Onion port can remain `80` whether Core listens
+on port `80`, `8123`, or another configured HTTP port.
+
+For more advanced mappings, for example:
 
 ```yaml
 ports:
@@ -163,8 +174,12 @@ When a mapping targets `homeassistant`, either explicitly or because no host
 was specified, and uses local port `80` or `8123`, the app gets the actual
 Home Assistant Core port from Supervisor and uses it as the hidden-service
 target. The published Onion port remains exactly as configured. This keeps
-existing mappings such as `8123` and `8123:80` working when Home Assistant
+existing saved mappings such as `8123` and `8123:80` working when Home Assistant
 Core listens on another port.
+
+The Ports field in the app configuration shows the saved mapping, not the
+resolved Home Assistant Core target. On startup, the app log shows both the
+detected Core port and each effective Onion-to-target mapping.
 
 Other local ports, and mappings to other hostnames or IP addresses, continue
 to use the configured local port exactly as specified.

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -70,7 +70,7 @@ dealing with an unknown issue. Possible values are:
 - `error`: Runtime errors that do not require immediate action.
 - `fatal`: Something went terribly wrong. App becomes unusable.
 
-Please note that each level automatically includes log messages from a
+Please note that each level automatically includes messages from a
 more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
@@ -159,6 +159,16 @@ The accepted syntax of this configuration is:
 If you do not define a published port, the local port will be used.
 If you do not define a hostname or IP address `homeassistant` will be used.
 
+When a mapping targets `homeassistant`, either explicitly or because no host
+was specified, the app automatically gets the actual Home Assistant Core port
+from Supervisor and uses that port as the hidden-service target. The published
+Onion port is still taken from the configuration as before. This allows
+existing mappings such as `8123` and `8123:80` to keep working even when Home
+Assistant Core is configured to listen on another port.
+
+Mappings that target any other hostname or IP address continue to use the local
+port from the configuration exactly as specified.
+
 ### Option: `bridges`
 
 > Ensure the option value is clear to avoid unintended use of transport plugins and bridges.
@@ -211,7 +221,7 @@ bridges:
     url=https://snowflake-broker.torproject.net/
     ampcache=https://cdn.ampproject.org/
     front=www.google.com
-    ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:3478
+    ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.uls.co.za:3478,stun:stun.voys.nl:3478
     utls-imitate=hellorandomizedalpn
 ```
 
@@ -312,7 +322,7 @@ You could also [open an issue here][issue] GitHub.
 The original setup of this repository is by [Franck Nijhof][frenck].
 
 For a full list of all authors and contributors,
-check [the contributor's page][contributors].
+check the contributor's page][contributors].
 
 ## License
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -70,7 +70,7 @@ dealing with an unknown issue. Possible values are:
 - `error`: Runtime errors that do not require immediate action.
 - `fatal`: Something went terribly wrong. App becomes unusable.
 
-Please note that each level automatically includes messages from a
+Please note that each level automatically includes log messages from a
 more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
@@ -221,7 +221,7 @@ bridges:
     url=https://snowflake-broker.torproject.net/
     ampcache=https://cdn.ampproject.org/
     front=www.google.com
-    ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.uls.co.za:3478,stun:stun.voys.nl:3478
+    ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:3478
     utls-imitate=hellorandomizedalpn
 ```
 
@@ -322,7 +322,7 @@ You could also [open an issue here][issue] GitHub.
 The original setup of this repository is by [Franck Nijhof][frenck].
 
 For a full list of all authors and contributors,
-check the contributor's page][contributors].
+check [the contributor's page][contributors].
 
 ## License
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -160,14 +160,14 @@ If you do not define a published port, the local port will be used.
 If you do not define a hostname or IP address `homeassistant` will be used.
 
 When a mapping targets `homeassistant`, either explicitly or because no host
-was specified, the app automatically gets the actual Home Assistant Core port
-from Supervisor and uses that port as the hidden-service target. The published
-Onion port is still taken from the configuration as before. This allows
-existing mappings such as `8123` and `8123:80` to keep working even when Home
-Assistant Core is configured to listen on another port.
+was specified, and uses local port `80` or `8123`, the app gets the actual
+Home Assistant Core port from Supervisor and uses it as the hidden-service
+target. The published Onion port remains exactly as configured. This keeps
+existing mappings such as `8123` and `8123:80` working when Home Assistant
+Core listens on another port.
 
-Mappings that target any other hostname or IP address continue to use the local
-port from the configuration exactly as specified.
+Other local ports, and mappings to other hostnames or IP addresses, continue
+to use the configured local port exactly as specified.
 
 ### Option: `bridges`
 

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -25,8 +25,7 @@ options:
   stealth: false
   client_names: []
   ports:
-    - "8123"
-    - "8123:80"
+    - "80"
   bridges: []
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -9,6 +9,7 @@ arch:
   - aarch64
   - amd64
 init: false
+hassio_api: true
 ports:
   9050/tcp: 9050
   9080/tcp: 9080

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -6,7 +6,7 @@
 # ==============================================================================
 declare address
 declare clientname
-declare homeassistant_port
+declare homeassistant_port=''
 declare host
 declare key
 declare log_level
@@ -130,7 +130,8 @@ if bashio::config.true 'hidden_services'; then
             bashio::log.warning "$port is not in the correct format, skipping..."
         fi
         if [[ "${count}" -le 2 ]]; then
-            if [[ "${host}" == 'homeassistant' ]]; then
+            if [[ "${host}" == 'homeassistant' ]] \
+                && [[ "${virtual_port}" == '80' || "${virtual_port}" == '8123' ]]; then
                 if [[ -z "${homeassistant_port}" ]]; then
                     if ! homeassistant_port=$(
                         bashio::api.supervisor GET /core/info false '.port'
@@ -230,7 +231,7 @@ then
 
             public_key=$(
                 openssl pkey -pubout \
-                <<< "${key}" \
+                    <<< "${key}" \
                 | sed -e '/----.*PUBLIC KEY----\|^[[:space:]]*$/d' \
                 | base64 -d \
                 | tail -c 32 \

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -231,7 +231,7 @@ then
 
             public_key=$(
                 openssl pkey -pubout \
-                    <<< "${key}" \
+                <<< "${key}" \
                 | sed -e '/----.*PUBLIC KEY----\|^[[:space:]]*$/d' \
                 | base64 -d \
                 | tail -c 32 \

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -149,10 +149,13 @@ if bashio::config.true 'hidden_services'; then
                     fi
 
                     bashio::log.info \
-                        "Detected Home Assistant Core port: ${homeassistant_port}"
+                        "Home Assistant Core port detected: ${homeassistant_port}"
                 fi
                 virtual_port="${homeassistant_port}"
             fi
+
+            bashio::log.info \
+                "Publishing Onion port ${target_port} -> ${host}:${virtual_port}"
             echo "HiddenServicePort ${target_port} ${host}:${virtual_port}" \
                 >> "${torrc}"
         fi

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -102,23 +102,6 @@ fi
 
 # Configure hidden services
 if bashio::config.true 'hidden_services'; then
-    if ! homeassistant_port=$(
-        bashio::api.supervisor GET /core/info false '.port'
-    ); then
-        bashio::log.fatal 'Unable to determine the Home Assistant Core port.'
-        bashio::exit.nok
-    fi
-
-    if ! [[ "${homeassistant_port}" =~ ^[0-9]+$ ]] \
-        || (( homeassistant_port < 1 || homeassistant_port > 65535 )); then
-        bashio::log.fatal \
-            "Supervisor returned an invalid Home Assistant Core port: ${homeassistant_port}"
-        bashio::exit.nok
-    fi
-
-    bashio::log.info \
-        "Detected Home Assistant Core port: ${homeassistant_port}"
-
     echo "HiddenServiceDir ${hidden_service_dir}" >> "${torrc}"
     
     for port in $(bashio::config 'ports'); do
@@ -148,6 +131,25 @@ if bashio::config.true 'hidden_services'; then
         fi
         if [[ "${count}" -le 2 ]]; then
             if [[ "${host}" == 'homeassistant' ]]; then
+                if [[ -z "${homeassistant_port}" ]]; then
+                    if ! homeassistant_port=$(
+                        bashio::api.supervisor GET /core/info false '.port'
+                    ); then
+                        bashio::log.fatal \
+                            'Unable to determine the Home Assistant Core port.'
+                        bashio::exit.nok
+                    fi
+
+                    if ! [[ "${homeassistant_port}" =~ ^[0-9]+$ ]] \
+                        || (( homeassistant_port < 1 || homeassistant_port > 65535 )); then
+                        bashio::log.fatal \
+                            "Supervisor returned an invalid Home Assistant Core port: ${homeassistant_port}"
+                        bashio::exit.nok
+                    fi
+
+                    bashio::log.info \
+                        "Detected Home Assistant Core port: ${homeassistant_port}"
+                fi
                 virtual_port="${homeassistant_port}"
             fi
             echo "HiddenServicePort ${target_port} ${host}:${virtual_port}" \

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -6,6 +6,7 @@
 # ==============================================================================
 declare address
 declare clientname
+declare homeassistant_port
 declare host
 declare key
 declare log_level
@@ -101,6 +102,23 @@ fi
 
 # Configure hidden services
 if bashio::config.true 'hidden_services'; then
+    if ! homeassistant_port=$(
+        bashio::api.supervisor GET /core/info false '.port'
+    ); then
+        bashio::log.fatal 'Unable to determine the Home Assistant Core port.'
+        bashio::exit.nok
+    fi
+
+    if ! [[ "${homeassistant_port}" =~ ^[0-9]+$ ]] \
+        || (( homeassistant_port < 1 || homeassistant_port > 65535 )); then
+        bashio::log.fatal \
+            "Supervisor returned an invalid Home Assistant Core port: ${homeassistant_port}"
+        bashio::exit.nok
+    fi
+
+    bashio::log.info \
+        "Detected Home Assistant Core port: ${homeassistant_port}"
+
     echo "HiddenServiceDir ${hidden_service_dir}" >> "${torrc}"
     
     for port in $(bashio::config 'ports'); do
@@ -129,6 +147,9 @@ if bashio::config.true 'hidden_services'; then
             bashio::log.warning "$port is not in the correct format, skipping..."
         fi
         if [[ "${count}" -le 2 ]]; then
+            if [[ "${host}" == 'homeassistant' ]]; then
+                virtual_port="${homeassistant_port}"
+            fi
             echo "HiddenServicePort ${target_port} ${host}:${virtual_port}" \
                 >> "${torrc}"
         fi


### PR DESCRIPTION
# Proposed Changes

Fixes #329.

Resolve the actual Home Assistant Core target port from Supervisor for the standard Home Assistant HTTP hidden-service mappings instead of assuming the configured local port is still Core's active port.

- enable Supervisor API access with `hassio_api: true`, without requesting an elevated role;
- query `GET /core/info` lazily and cache its `.port` value while generating the Tor mappings;
- preserve every configured published Onion port;
- substitute the local target only when the mapping resolves to `homeassistant` and its configured local port is `80` or `8123`;
- use Onion port `80` as the default saved mapping for new installations;
- keep existing saved `8123` / `8123:80` configurations compatible;
- leave other local ports, hostnames and IP mappings unchanged, preserving generic uses such as `homeassistant:22`;
- validate the Supervisor-provided port and fail with a clear error if it cannot be resolved;
- log the detected Core port and each effective Onion-to-target mapping at startup;
- document that the configuration UI shows the saved mapping while the startup log shows the resolved target.

For a new installation, the default becomes:

```yaml
ports:
  - "80"
```

If Core listens on port 80, the effective mapping is:

```text
80 -> HiddenServicePort 80 homeassistant:80
```

If Core instead listens on 8123 or another configured HTTP port, the Onion URL remains on port 80 while only the internal target changes.

Existing saved configurations remain compatible. For example, with Core listening on port 80:

```text
8123      -> HiddenServicePort 8123 homeassistant:80
8123:80   -> HiddenServicePort 80   homeassistant:80
```

The resolution happens when the Tor app starts and its `torrc` is generated. If the Core HTTP port is changed while Tor is already running, restarting the Tor app is still required, but editing its `ports` configuration is not.

The branch is based directly on current `main` and is intentionally independent of #328, so this fix can be reviewed and merged regardless of the dependency/build migration.

## Validation

The original failure and workaround were reproduced on Home Assistant OS after moving Core from port 8123 to port 80.

The implementation was then tested in an isolated local Tor app on:

- Home Assistant OS 18.2;
- Home Assistant Core 2026.8.2;
- Home Assistant Supervisor 2026.07.5.

The test app used a separate slug, separate SOCKS/HTTP proxy host ports, and a separate hidden-service directory so the production Tor app and its Onion keys were untouched. Because current `main` has the unrelated build failure tracked in #327, the local test image used the already validated #328 Alpine/base build layer while overlaying the exact three files changed by this PR.

With the test app deliberately retaining the legacy saved configuration:

```yaml
ports:
  - "8123"
  - "8123:80"
```

while Home Assistant Core was actually listening on port 80:

- the app logged `Detected Home Assistant Core port: 80` with the initial implementation;
- the isolated SOCKS proxy successfully reached the Tor Project check page;
- `http://<test-address>.onion/` returned HTTP 200;
- `http://<test-address>.onion:8123/` also returned HTTP 200;
- the Home Assistant login page loaded through the test Onion service.

This validates the important compatibility path: existing `8123` / `8123:80` settings can follow Core after it moves to port 80 without editing the Tor configuration or changing the Onion address.

The final follow-up changes in this draft switch the new-install default to `80` and add explicit effective-mapping log lines. A short revalidation of those final log/default changes is still pending before marking the PR ready for review.

The implementation is compatible with the base image currently used by `main`: base `20.1.1` includes Bashio `v0.17.5`, whose `bashio::api.supervisor` helper already supports the jq filter argument used here.

Current `main` also has the unrelated build failure tracked in #327 and addressed by #328. Docker build checks on this PR may therefore remain red until that issue is resolved; this PR does not touch the Dockerfile or build dependencies.

## Related Issues

Fixes #329.

Historical context: #141 added `8123:80` to expose Home Assistant on Onion port 80 while Home Assistant itself was expected on 8123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Home Assistant API access for the Tor add-on.
  * Added automatic detection of the active Home Assistant Core port, supporting ports 80 and 8123.
  * Default Home Assistant mapping now uses local port 80.
* **Bug Fixes**
  * Preserved configured Onion service mappings while maintaining compatibility with existing configurations.
  * Added validation and clear startup logging when the Home Assistant port is detected or cannot be resolved.
* **Documentation**
  * Updated port configuration guidance, saved mapping details, and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->