### PR TITLE
Add automatic Home Assistant port mapping

### DIFF
--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -237,7 +237,7 @@ bridges:
     fingerprint=2B280B23E1107BB62ABFC40DDCC8824814F80A72
     url=https://snowflake-broker.torproject.net/
     ampcache=https://cdn.ampproject.org/
-    front=www.google.com/
+    front=www.google.com
     ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:3478
     utls-imitate=hellorandomizedalpn
 ```
@@ -327,7 +327,7 @@ You have several options to get them answered:
 
 - The [Home Assistant Community Apps Discord chat server][discord] for app
   support and feature requests.
-- The Home Assistant Discord chat server][discord-ha] for general Home
+- The [Home Assistant Discord chat server][discord-ha] for general Home
   Assistant discussions and questions.
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
@@ -339,7 +339,7 @@ You could also [open an issue here][issue] GitHub.
 The original setup of this repository is by [Franck Nijhof][frenck].
 
 For a full list of authors and contributors,
-check the contributor's page][contributors].
+check the [contributor's page][contributors].
 
 ## License
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -140,32 +140,26 @@ section below for details.
 Configures hosts and ports to publish via a Tor Hidden Service.
 You can list multiple hosts and ports to publish.
 
-For normal Home Assistant access, use `auto`:
+For example:
+
+```yaml
+ports:
+  - "homeassistant:8123:80"
+  - 22
+```
+
+For normal Home Assistant access, `auto` can be used instead of configuring
+its HTTP port manually:
 
 ```yaml
 ports:
   - "auto"
 ```
 
-The app gets the active Home Assistant Core port from Supervisor when it
-starts. `auto` always publishes Home Assistant on Onion port `80`. When the
-detected Core port is not `80`, it also publishes the same Onion port number.
-
-For example, if Home Assistant Core listens on port `8123`, `auto` generates
-the equivalent of:
-
-```text
-HiddenServicePort 80 homeassistant:8123
-HiddenServicePort 8123 homeassistant:8123
-```
-
-If Home Assistant Core listens on port `80`, only this mapping is needed:
-
-```text
-HiddenServicePort 80 homeassistant:80
-```
-
-Manual mappings can still be added alongside `auto` for advanced use.
+At startup, `auto` gets the active Home Assistant Core port from Supervisor.
+It publishes Home Assistant on Onion port `80` and, when the detected Core port
+is not `80`, also publishes that same port number. Manual mappings can still be
+used alongside `auto`.
 
 The accepted syntax of this configuration is:
 
@@ -178,7 +172,6 @@ The accepted syntax of this configuration is:
 
 If you do not define a published port, the local port will be used.
 If you do not define a hostname or IP address `homeassistant` will be used.
-Manual mappings retain their existing behavior and are not changed by `auto`.
 
 ### Option: `bridges`
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -91,8 +91,7 @@ network, and allow anybody to use your computer as an open proxy._
 
 Setting this option to `true` opens port `9080` to listen for connections from
 HTTP-speaking applications. Enabling this feature allows you to use other
-applications on your local network to access the Tor network via the HTTP
-proxy.
+applications on your network to access the Tor network via the HTTP proxy.
 
 ### Option: `hidden_services`
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -51,7 +51,7 @@ client_names:
   - haremote1
   - haremote2
 ports:
-  - 8123
+  - auto
 bridges: []
 ```
 
@@ -140,16 +140,42 @@ section below for details.
 Configures hosts and ports to publish via a Tor Hidden Service.
 You can list multiple hosts and ports to publish.
 
-For example:
+For normal Home Assistant access, use `auto`:
 
 ```yaml
 ports:
-  - "homeassistant:8123:80"
-  - 22
+  - "auto"
+```
+
+The app gets the active Home Assistant Core port from Supervisor when it
+starts. `auto` always publishes Home Assistant on Onion port `80`. When the
+detected Core port is not `80`, it also publishes the same Onion port number.
+
+For example, if Home Assistant Core listens on port `8123`, `auto` generates
+the equivalent of:
+
+```text
+HiddenServicePort 80 homeassistant:8123
+HiddenServicePort 8123 homeassistant:8123
+```
+
+If Home Assistant Core listens on port `80`, only this mapping is needed:
+
+```text
+HiddenServicePort 80 homeassistant:80
+```
+
+Manual mappings can be added alongside `auto` for advanced use. For example:
+
+```yaml
+ports:
+  - "auto"
+  - "192.168.1.60:22:2222"
 ```
 
 The accepted syntax of this configuration is:
 
+- automatic Home Assistant mapping `"auto"`
 - hostname:local_port:published_port `"homeassistant:8123:8080"`
 - local_ip:local_port:published_port `"192.168.1.60:8123:8080"`
 - hostname:local_port `"homeassistant:8123"`
@@ -158,6 +184,7 @@ The accepted syntax of this configuration is:
 
 If you do not define a published port, the local port will be used.
 If you do not define a hostname or IP address `homeassistant` will be used.
+Manual mappings retain their existing behavior and are not changed by `auto`.
 
 ### Option: `bridges`
 
@@ -210,7 +237,7 @@ bridges:
     fingerprint=2B280B23E1107BB62ABFC40DDCC8824814F80A72
     url=https://snowflake-broker.torproject.net/
     ampcache=https://cdn.ampproject.org/
-    front=www.google.com
+    front=www.google.com/
     ice=stun:stun.l.google.com:19302,stun:stun.antisip.com:3478,stun:stun.bluesip.net:3478,stun:stun.dus.net:3478,stun:stun.epygi.com:3478,stun:stun.sonetel.com:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:3478
     utls-imitate=hellorandomizedalpn
 ```
@@ -300,7 +327,7 @@ You have several options to get them answered:
 
 - The [Home Assistant Community Apps Discord chat server][discord] for app
   support and feature requests.
-- The [Home Assistant Discord chat server][discord-ha] for general Home
+- The Home Assistant Discord chat server][discord-ha] for general Home
   Assistant discussions and questions.
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
@@ -311,8 +338,8 @@ You could also [open an issue here][issue] GitHub.
 
 The original setup of this repository is by [Franck Nijhof][frenck].
 
-For a full list of all authors and contributors,
-check [the contributor's page][contributors].
+For a full list of authors and contributors,
+check the contributor's page][contributors].
 
 ## License
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -91,7 +91,8 @@ network, and allow anybody to use your computer as an open proxy._
 
 Setting this option to `true` opens port `9080` to listen for connections from
 HTTP-speaking applications. Enabling this feature allows you to use other
-applications on your network to access the Tor network via the HTTP proxy.
+applications on your local network to access the Tor network via the HTTP
+proxy.
 
 ### Option: `hidden_services`
 
@@ -165,13 +166,7 @@ If Home Assistant Core listens on port `80`, only this mapping is needed:
 HiddenServicePort 80 homeassistant:80
 ```
 
-Manual mappings can be added alongside `auto` for advanced use. For example:
-
-```yaml
-ports:
-  - "auto"
-  - "192.168.1.60:22:2222"
-```
+Manual mappings can still be added alongside `auto` for advanced use.
 
 The accepted syntax of this configuration is:
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -158,8 +158,25 @@ ports:
 
 At startup, `auto` gets the active Home Assistant Core port from Supervisor.
 It publishes Home Assistant on Onion port `80` and, when the detected Core port
-is not `80`, also publishes that same port number. Manual mappings can still be
-used alongside `auto`.
+is not `80`, also publishes that same port number. Manual mappings for other
+services can still be used alongside `auto`.
+
+When updating from an earlier version, existing saved `ports` values are
+preserved. Replace the previous Home Assistant mappings with `auto` rather than
+adding `auto` alongside them. Other manual mappings can be kept unchanged:
+
+```yaml
+# Before
+ports:
+  - "8123"
+  - "8123:80"
+  - 22
+
+# After
+ports:
+  - "auto"
+  - 22
+```
 
 The accepted syntax of this configuration is:
 
@@ -338,8 +355,8 @@ Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -338,8 +338,8 @@ You could also [open an issue here][issue] GitHub.
 
 The original setup of this repository is by [Franck Nijhof][frenck].
 
-For a full list of authors and contributors,
-check the [contributor's page][contributors].
+For a full list of all authors and contributors,
+check [the contributor's page][contributors].
 
 ## License
 

--- a/tor/DOCS.md
+++ b/tor/DOCS.md
@@ -355,8 +355,8 @@ Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is furnished
-to do so, subject to the following conditions:
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -9,6 +9,7 @@ arch:
   - aarch64
   - amd64
 init: false
+hassio_api: true
 ports:
   9050/tcp: 9050
   9080/tcp: 9080
@@ -24,8 +25,7 @@ options:
   stealth: false
   client_names: []
   ports:
-    - "8123"
-    - "8123:80"
+    - "auto"
   bridges: []
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
@@ -36,6 +36,6 @@ schema:
   client_names:
     - match(^[A-Za-z0-9+-_]{1,16}$)
   ports:
-    - match(^(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$)
+    - match(^(?:auto|(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?)$)
   bridges:
     - str

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -6,6 +6,7 @@
 # ==============================================================================
 declare address
 declare clientname
+declare homeassistant_port=''
 declare host
 declare key
 declare log_level
@@ -104,6 +105,41 @@ if bashio::config.true 'hidden_services'; then
     echo "HiddenServiceDir ${hidden_service_dir}" >> "${torrc}"
     
     for port in $(bashio::config 'ports'); do
+        if [[ "${port}" == 'auto' ]]; then
+            if [[ -z "${homeassistant_port}" ]]; then
+                if ! homeassistant_port=$(
+                    bashio::api.supervisor GET /core/info false '.port'
+                ); then
+                    bashio::log.fatal \
+                        'Unable to determine the Home Assistant Core port.'
+                    bashio::exit.nok
+                fi
+
+                if ! [[ "${homeassistant_port}" =~ ^[0-9]+$ ]] \
+                    || (( homeassistant_port < 1 || homeassistant_port > 65535 )); then
+                    bashio::log.fatal \
+                        "Supervisor returned an invalid Home Assistant Core port: ${homeassistant_port}"
+                    bashio::exit.nok
+                fi
+
+                bashio::log.info \
+                    "Home Assistant Core port detected: ${homeassistant_port}"
+            fi
+
+            bashio::log.info \
+                "Publishing Onion port 80 -> homeassistant:${homeassistant_port}"
+            echo "HiddenServicePort 80 homeassistant:${homeassistant_port}" \
+                >> "${torrc}"
+
+            if [[ "${homeassistant_port}" != '80' ]]; then
+                bashio::log.info \
+                    "Publishing Onion port ${homeassistant_port} -> homeassistant:${homeassistant_port}"
+                echo "HiddenServicePort ${homeassistant_port} homeassistant:${homeassistant_port}" \
+                    >> "${torrc}"
+            fi
+            continue
+        fi
+
         count=$(echo "${port}" | sed 's/[^:]//g'| awk '{ print length }')
         if [[ "${count}" == 0 ]]; then
             host='homeassistant'

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -107,9 +107,7 @@ if bashio::config.true 'hidden_services'; then
     for port in $(bashio::config 'ports'); do
         if [[ "${port}" == 'auto' ]]; then
             if [[ -z "${homeassistant_port}" ]]; then
-                if ! homeassistant_port=$(
-                    bashio::api.supervisor GET /core/info false '.port'
-                ); then
+                if ! homeassistant_port=$(bashio::core.port); then
                     bashio::log.fatal \
                         'Unable to determine the Home Assistant Core port.'
                     bashio::exit.nok

--- a/tor/translations/en.yaml
+++ b/tor/translations/en.yaml
@@ -28,8 +28,8 @@ configuration:
   ports:
     name: Ports
     description: >-
-      Use `auto` to publish Home Assistant using the Core port detected from
-      Supervisor. Additional manual mappings can be added for advanced use.
+      Configures hosts and ports to publish via a Tor Hidden Service. Use `auto`
+      to publish Home Assistant using the Core port detected from Supervisor.
       Check the app documentation for the supported formats.
   bridges:
     name: Bridges

--- a/tor/translations/en.yaml
+++ b/tor/translations/en.yaml
@@ -28,8 +28,9 @@ configuration:
   ports:
     name: Ports
     description: >-
-      Configures hosts and ports to publish via a Tor Hidden Service. Check
-      the app documentation for the exact format to enter here.
+      Use `auto` to publish Home Assistant using the Core port detected from
+      Supervisor. Additional manual mappings can be added for advanced use.
+      Check the app documentation for the supported formats.
   bridges:
     name: Bridges
     description: >-


### PR DESCRIPTION
# Proposed Changes

Fixes #329.

Introduce a single `auto` value for the normal Home Assistant hidden-service mapping while leaving the existing manual port syntax unchanged.

`auto` resolves the active Home Assistant Core port from Supervisor at app startup and publishes:

- Onion port `80` to the detected Home Assistant Core port;
- when the detected Core port is not `80`, the same detected port as an additional Onion port.

For example, with Core on `8123`:

```text
HiddenServicePort 80 homeassistant:8123
HiddenServicePort 8123 homeassistant:8123
```

With Core on `80`:

```text
HiddenServicePort 80 homeassistant:80
```

The implementation:

- enables Supervisor API access with `hassio_api: true`;
- changes the default `ports` value from `8123` / `8123:80` to `auto`;
- allows `auto` in the existing `ports` schema;
- resolves and validates the Core port only when `auto` is used;
- keeps every existing manual mapping format and parser behavior unchanged;
- allows manual mappings for other services alongside `auto`;
- documents the behavior and explains `auto` in the configuration UI.

## Upgrade behavior

Existing persisted `ports` values are preserved by Supervisor during an update. `auto` becomes the default for new/default configurations, but existing Home Assistant mappings are not migrated automatically.

Existing manual mappings continue to work unchanged. To make the Home Assistant mapping follow the active Core port automatically, replace the previous default mappings:

```yaml
ports:
  - "8123"
  - "8123:80"
```

with:

```yaml
ports:
  - "auto"
```

Other manual service mappings can be kept unchanged.

This intentionally does **not** add migration logic, persisted mode markers, `auto:<published_port>` syntax, or reinterpret existing manual mappings.

## Validation

The feature branch is based directly on current `main` and remains independent from the separate Alpine/base-image migration in #328.

Static repository checks pass:

- Shellcheck ✅
- YAMLLint ✅
- Prettier ✅
- JSON Lint ✅
- App Lint ✅
- Hadolint ✅
- zizmor ✅
- Gather app information ✅

Current `main` still has the unrelated image-build problem tracked by #327 / #328. To validate this feature without coupling the changes, the same runtime/config implementation was overlaid on the build-fixed branch in temporary fork PR https://github.com/eXPerience83/app-tor/pull/4. On that buildable base:

- Build amd64 ✅
- Build aarch64 ✅
- all static checks above ✅

The only failing job in that fork validation was Dependency review because Dependency Graph is not enabled in the fork; it is unrelated to these source changes.

### Home Assistant OS runtime validation

The final `auto` runtime/config behavior was validated in an isolated local app on:

- Home Assistant OS 18.2 (amd64 / generic-x86-64)
- Home Assistant Core 2026.8.2
- Home Assistant Supervisor 2026.07.5
- active Core port: `80`

The test app used a separate slug, separate SOCKS/HTTP host ports, and a separate `/ssl` path so the production Tor app and its Onion keys were untouched.

With a fresh/default configuration, Supervisor reported:

```json
"ports": ["auto"]
```

At startup the app logged:

```text
Home Assistant Core port detected: 80
Publishing Onion port 80 -> homeassistant:80
```

No second automatic mapping was generated, as expected when the detected Core port is already `80`.

Runtime results:

- Tor bootstrapped to 100% ✅
- Tor Browser reached the Home Assistant login page through the test `.onion` address ✅
- the isolated SOCKS proxy reached the Tor Project check page ✅
- `curl` to the test `.onion` through that SOCKS proxy returned HTTP 200 ✅
- after restarting the app, Core port `80` was detected again, the same mapping was generated, the same Onion address was preserved, and Tor bootstrapped to 100% again ✅

Upgrade/default behavior was also checked directly through Supervisor:

- explicitly saved legacy values `8123` / `8123:80` remained persisted unchanged ✅
- using Reset to defaults restored `ports` to `["auto"]` ✅

Fork design/validation PR: https://github.com/eXPerience83/app-tor/pull/3

The earlier draft #330 used a different compatibility approach and was closed before this explicit `auto` design was finalized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Home Assistant port discovery for Tor Hidden Services.
  * The default Tor configuration now publishes Home Assistant automatically, including Onion port mappings.
  * Added support for the `auto` port configuration option.

* **Documentation**
  * Updated configuration guidance, supported port formats, migration steps, and English translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->