### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -59,8 +66,16 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": ["alpine_3_24/go", "alpine_3_24/tor"],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the organization: every `alpine_X_YY/*` lookup returns no result, so the pins in the Dockerfile are no longer updated at all. This applies the same fix already landed on `app-ssh` in [hassio-addons/app-ssh#1119](https://github.com/hassio-addons/app-ssh/pull/1119).

- Added a `custom.alpine` datasource pointing at the Alpine CDN directory listing, using the `html` format so every `href` in the listing becomes a version candidate.
- Switched the Alpine custom manager from `repology` to `custom.alpine`, with `extractVersionTemplate` pulling the version out of the apk filename. The `\d` in that regex is what stops a package from matching a longer sibling name, such as `go` matching `go-bootstrap-*`.
- Replaced the `repology` entry in `packageRules` with `custom.alpine`. This repository only had one.
- Added a rule listing the pinned packages that live in the Alpine **community** repository, with an explicit `registryUrls`. Custom datasources use `registryStrategy: "first"`, so community packages do not resolve without it. The list was derived mechanically from this repository's Dockerfile against the `v3.24` `APKINDEX` files, and is `go` and `tor`.

One thing worth calling out, since it deviates from a straight port: `depNameTemplate` still said `alpine_3_23`, while the base image has since moved to Alpine 3.24 (`ghcr.io/hassio-addons/base:21.0.2` reports `3.24.1`, and the pins in the Dockerfile are 3.24 versions). Resolving against the 3.23 listing would have been wrong, so it is corrected to `alpine_3_24` here. Dependency Dashboard entries will be renamed accordingly.

### Verification

Config validated with `renovate-config-validator`, and a local `RENOVATE_DRY_RUN=lookup` run against this working tree (the containerized Renovate, not CI):

- All 5 Alpine pins in `tor/Dockerfile` are extracted and resolved: `coreutils`, `git`, `openssl` (main) and `go`, `tor` (community). That matches the pin count in the Dockerfile exactly.
- Zero lookup failures and zero warnings or errors in the run. Every pinned package exists in either the main or the community index, so there are no unbuildable pins.
- Zero updates proposed, which is correct: the pins were all brought to the latest 3.24 versions in #321, and they match the `APKINDEX` contents.

Because a clean run proposing nothing is weak evidence on its own, the same dry run was repeated against a scratch copy with three pins deliberately rolled back (`coreutils`, `tor`, `go`, covering both the main and the community path). Renovate found exactly those three updates and targeted `coreutils` 9.11-r0, `tor` 0.4.9.11-r0 and `go` 1.26.3-r0, agreeing with the `APKINDEX` files.

Note that a green CI run on this PR proves nothing about the datasource: the config change does not touch the Dockerfile, so the `apk` layer is served from cache and no `apk add` runs. The local dry run is the evidence.

No stale pin is currently blocking another PR in this repository.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Ports [hassio-addons/app-ssh#1119](https://github.com/hassio-addons/app-ssh/pull/1119) to this repository.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/